### PR TITLE
Fix out-of-range world generation value

### DIFF
--- a/src/main/java/net/sheddmer/abundant_atmosphere/common/world/generation/AABiomePlacements.java
+++ b/src/main/java/net/sheddmer/abundant_atmosphere/common/world/generation/AABiomePlacements.java
@@ -12,7 +12,7 @@ public class AABiomePlacements {
             BiomePlacement.addOverworld(AABiomes.ERODED_BAMBOO_JUNGLE,
                     Climate.parameters(
                             Climate.Parameter.span(0.2F, 0.55F),
-                            Climate.Parameter.span(0.2F, 9.0F),
+                            Climate.Parameter.span(0.2F, 0.9F),
                             Climate.Parameter.span(0.0F, 0.35F),
                             Climate.Parameter.span(-0.05F, 0.35F),
                             Climate.Parameter.span(0.0F, 0.0F),


### PR DESCRIPTION
After a bit of debugging to solve my issue seen in #4, I noticed a suspicious log line which led me to a world generation parameter that looked suspiciously like a typo. After changing it to fall within the correct range, the issue no longer occurs.

Fixes #4